### PR TITLE
Fix auto-swing issue

### DIFF
--- a/InitiumPro.js
+++ b/InitiumPro.js
@@ -140,7 +140,7 @@ function loadLocalMerchantDetails() {
 function keepPunching() {
     //for a more CircleMUD feel
     if(AUTO_SWING) {
-        if(loc.type==="in a fight!" && window.urlParams.type==="attack" && player.health>AUTO_FLEE) {
+        if((loc.type==="in a fight!" || loc.type==="in combat!") && window.urlParams.type==="attack" && player.health>AUTO_FLEE) {
             if(window.urlParams.hand==="RightHand")  window.combatAttackWithRightHand();  else  window.combatAttackWithLeftHand();
             combatMessage("Attacking with "+window.urlParams.hand,"AUTO-SWING");
         }


### PR DESCRIPTION
Autoswing was checking for "in a fight!" as its location type, whereas the actual text while in combat is "in combat!".